### PR TITLE
fix(399): Catching up to new version of `data-schema`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-base",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "Base class defining the interface for executor implementations",
   "main": "index.js",
   "scripts": {
@@ -40,11 +40,11 @@
     "chai": "^3.5.0",
     "eslint": "^3.4.0",
     "eslint-config-screwdriver": "^2.0.0",
-    "jenkins-mocha": "^3.0.0",
+    "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0"
   },
   "dependencies": {
     "joi": "^10.0.5",
-    "screwdriver-data-schema": "^15.0.3"
+    "screwdriver-data-schema": "^16.0.0"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,18 +114,18 @@ describe('index test', () => {
 
     it('can be extended', () => {
         class Foo extends Executor {
-            _stop(config, callback) {
-                return callback(null, config);
+            _stop(config) {
+                return Promise.resolve(config);
             }
         }
 
         const bar = new Foo({ foo: 'bar' });
 
         assert.instanceOf(bar, Executor);
-        bar.stop({
+
+        return bar.stop({
             buildId: 'a'
-        }, (err, data) => {
-            assert.isNull(err);
+        }).then((data) => {
             assert.equal(data.buildId, 'a');
         });
     });


### PR DESCRIPTION
This should not affect affect the Executor module as it doesn't depend on any of the id => hash specific changes.

Epic: screwdriver-cd/screwdriver#399