### PR TITLE
fix: reject with error object instead of string

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ class Executor {
     }
 
     _start() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -66,7 +66,7 @@ class Executor {
     }
 
     _stop() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**
@@ -82,7 +82,7 @@ class Executor {
     }
 
     _status() {
-        return Promise.reject('Not implemented');
+        return Promise.reject(new Error('Not implemented'));
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -58,7 +58,7 @@ describe('index test', () => {
                 throw new Error('Oh no');
             }, (err) => {
                 assert.isOk(err, 'err is null');
-                assert.equal(err, 'Not implemented');
+                assert.equal(err.message, 'Not implemented');
             })
     ));
 
@@ -78,7 +78,7 @@ describe('index test', () => {
                 throw new Error('Oh no');
             }, (err) => {
                 assert.isOk(err, 'error is null');
-                assert.equal(err, 'Not implemented');
+                assert.equal(err.message, 'Not implemented');
             })
     ));
 
@@ -98,7 +98,7 @@ describe('index test', () => {
                 throw new Error('Oh no');
             }, (err) => {
                 assert.isOk(err, 'error is null');
-                assert.equal(err, 'Not implemented');
+                assert.equal(err.message, 'Not implemented');
             })
     ));
 


### PR DESCRIPTION
Reject with error object instead of string.

This is giving us problem when we catch the err in the API and try to wrap it with `boom.wrap(err)`. `boom.wrap` assumes `err` is an error object.
https://github.com/hapijs/boom#wraperror-statuscode-message