### PR TITLE
fix(hip): Upgrade to node:8

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,19 +7,19 @@ const executorSchema = dataSchema.plugins.executor;
 
 /**
  * Validate the config using the schema
- * @method  validate
+ * @async  validate
  * @param  {Object}    config       Configuration
  * @param  {Object}    schema       Joi object used for validation
  * @return {Promise}
  */
-function validate(config, schema) {
+async function validate(config, schema) {
     const result = Joi.validate(config, schema);
 
     if (result.error) {
-        return Promise.reject(result.error);
+        throw result.error;
     }
 
-    return Promise.resolve(config);
+    return config;
 }
 
 class Executor {
@@ -36,12 +36,12 @@ class Executor {
     /**
      * Start a new build
      * @method start
-     * @param {Object} config               Configuration
-     * @param {Object} [config.annotations] Optional key/value object
-     * @param {String} config.apiUri        Screwdriver's API
-     * @param {String} config.buildId       Unique ID for a build
-     * @param {String} config.container     Container for the build to run in
-     * @param {String} config.token         JWT to act on behalf of the build
+     * @param  {Object} config               Configuration
+     * @param  {Object} [config.annotations] Optional key/value object
+     * @param  {String} config.apiUri        Screwdriver's API
+     * @param  {String} config.buildId       Unique ID for a build
+     * @param  {String} config.container     Container for the build to run in
+     * @param  {String} config.token         JWT to act on behalf of the build
      * @return {Promise}
      */
     start(config) {
@@ -49,15 +49,15 @@ class Executor {
             .then(validConfig => this._start(validConfig));
     }
 
-    _start() {
-        return Promise.reject(new Error('Not implemented'));
+    async _start() {
+        throw new Error('Not implemented');
     }
 
     /**
      * Stop a running or finished build
      * @method stop
-     * @param {Object} config               Configuration
-     * @param {String} config.buildId       Unique ID for a build
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
      * @return {Promise}
      */
     stop(config) {
@@ -65,15 +65,15 @@ class Executor {
             .then(validConfig => this._stop(validConfig));
     }
 
-    _stop() {
-        return Promise.reject(new Error('Not implemented'));
+    async _stop() {
+        throw new Error('Not implemented');
     }
 
     /**
      * Get the status of a build
      * @method status
-     * @param {Object} config               Configuration
-     * @param {String} config.buildId       Unique ID for a build
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
      * @return {Promise}
      */
     status(config) {
@@ -81,8 +81,8 @@ class Executor {
             .then(validConfig => this._status(validConfig));
     }
 
-    _status() {
-        return Promise.reject(new Error('Not implemented'));
+    async _status() {
+        throw new Error('Not implemented');
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   },
   "devDependencies": {
     "chai": "^3.5.0",
-    "eslint": "^3.4.0",
-    "eslint-config-screwdriver": "^2.0.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
     "mockery": "^2.0.0"
   },

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,17 +1,16 @@
-workflow:
-    - publish
-
 shared:
-    image: node:6
+    image: node:8
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
-        template: screwdriver-cd/semantic-release 
+        requires: main
+        template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM
             - NPM_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const mockery = require('mockery');
 const Joi = require('joi');
 


### PR DESCRIPTION
## Context

Node.js 6 is slowly becoming deprecated, with popular packages such as `semantic-release` no longer supporting it. Aside from maintenance, upgrading to Node.js 8 also provides async functions, which simplify `Promise` control flow.

## Objective

* Change image in `screwdriver.yaml` to `node:8`
* Convert functions that return a `Promise` to `async` functions

#### Additional changes

* Update `screwdriver.yaml` workflow