### PR TITLE
fix: Remove obsolete 'requires' settings from sd.yaml

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -3,7 +3,6 @@ shared:
 
 jobs:
     main:
-        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
@@ -12,7 +11,6 @@ jobs:
             - ~commit
 
     publish:
-        requires: main
         template: screwdriver-cd/semantic-release
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
Builds are failing at the config-parse step because of the repeating setting.