### PR TITLE
fix(1030): Not to exchange token if it is already the build token

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
 const executorSchema = dataSchema.plugins.executor;
 const request = require('requestretry');
+const jwt = require('jsonwebtoken');
 const DEFAULT_BUILD_TIMEOUT = 90; // in minutes
 
 /**
@@ -22,6 +23,18 @@ async function validate(config, schema) {
     }
 
     return config;
+}
+
+/**
+ * Check if the scope of jwt is temporal or not
+ * @async  isTemporalJwt
+ * @param  {String}  token Jwt
+ * @return {Boolean}
+ */
+function isTemporalJwt(token) {
+    const decoded = jwt.decode(token);
+
+    return decoded.scope.includes('temporal');
 }
 
 class Executor {
@@ -135,6 +148,10 @@ class Executor {
      * @return {Promise}
      */
     async exchangeTokenForBuild(config, buildTimeout = DEFAULT_BUILD_TIMEOUT) {
+        if (!isTemporalJwt(config.token)) {
+            return config.token;
+        }
+
         if (isFinite(buildTimeout) === false) {
             throw new Error(`Invalid buildTimeout value: ${buildTimeout}`);
         }

--- a/index.js
+++ b/index.js
@@ -148,6 +148,7 @@ class Executor {
      * @return {Promise}
      */
     async exchangeTokenForBuild(config, buildTimeout = DEFAULT_BUILD_TIMEOUT) {
+        // Use token directly if the scope is already 'build' (#1030)
         if (!isTemporalJwt(config.token)) {
             return config.token;
         }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "joi": "^13.0.0",
+    "jsonwebtoken": "^8.2.2",
     "requestretry": "^1.13.0",
     "screwdriver-data-schema": "^18.20.0"
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -168,7 +168,7 @@ describe('index test', () => {
         let token;
 
         beforeEach(() => {
-            token = jwt.sign({ scope: ['temporal'] }, 'socmPrivateKey');
+            token = jwt.sign({ scope: ['temporal'] }, 'dummyPrivateKey');
             postConfig = {
                 buildId: 111,
                 apiUri: 'https://dummy.com',
@@ -208,8 +208,8 @@ describe('index test', () => {
             });
         });
 
-        it('do not exchange and returns token as it is if it is already build JWT', async () => {
-            token = jwt.sign({ scope: ['build'] }, 'socmPrivateKey');
+        it('does not exchange and return token as it is if it is already build JWT', async () => {
+            token = jwt.sign({ scope: ['build'] }, 'dummyPrivateKey');
             postConfig.token = token;
 
             await instance.exchangeTokenForBuild(postConfig).then((buildToken) => {


### PR DESCRIPTION
When releasing this feature, api and queue-worker have to be released at same time, but in CI/CD cycle, it is difficult.
So, I added the code that if the scope of JWT is already 'build' just return the token as it is.

Related:
https://github.com/screwdriver-cd/screwdriver/issues/1075
