### PR TITLE
fix: add buffer for JWT expiration time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ artifacts/
 npm-debug.log
 .DS_STORE
 .*.swp
+.nyc*

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const executorSchema = dataSchema.plugins.executor;
 const request = require('requestretry');
 const jwt = require('jsonwebtoken');
 const DEFAULT_BUILD_TIMEOUT = 90; // in minutes
+const DEFAULT_BUILD_TIMEOUT_BUFFER = 30; // in minutes
 
 /**
  * Validate the config using the schema
@@ -160,7 +161,7 @@ class Executor {
         const options = {
             uri: `${config.apiUri}/v4/builds/${config.buildId}/token`,
             method: 'POST',
-            body: { buildTimeout },
+            body: { buildTimeout: buildTimeout + DEFAULT_BUILD_TIMEOUT_BUFFER },
             headers: { Authorization: `Bearer ${config.token}` },
             strictSSL: true,
             json: true

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -6,6 +6,7 @@ const mockery = require('mockery');
 const Joi = require('joi');
 const jwt = require('jsonwebtoken');
 const DEFAULT_BUILD_TIMEOUT = 90; // in minutes
+const DEFAULT_BUILD_TIMEOUT_BUFFER = 30; // in minutes
 
 describe('index test', () => {
     let instance;
@@ -164,6 +165,7 @@ describe('index test', () => {
         let postConfig;
         let options;
         let buildTimeout;
+        let buildTimeoutWithBuffer;
         let fakeResponse;
         let token;
 
@@ -175,10 +177,11 @@ describe('index test', () => {
                 token
             };
             buildTimeout = 150;
+            buildTimeoutWithBuffer = buildTimeout + DEFAULT_BUILD_TIMEOUT_BUFFER;
             options = {
                 uri: `${postConfig.apiUri}/v4/builds/${postConfig.buildId}/token`,
                 method: 'POST',
-                body: { buildTimeout },
+                body: { buildTimeout: buildTimeoutWithBuffer },
                 headers: { Authorization: `Bearer ${postConfig.token}` },
                 strictSSL: true,
                 json: true
@@ -200,7 +203,7 @@ describe('index test', () => {
         });
 
         it('succeeds to exchange temporal JWT to build JWT without buildTimeout args', async () => {
-            options.body.buildTimeout = DEFAULT_BUILD_TIMEOUT;
+            options.body.buildTimeout = DEFAULT_BUILD_TIMEOUT + DEFAULT_BUILD_TIMEOUT_BUFFER;
             requestMock.withArgs(options).resolves(fakeResponse);
 
             await instance.exchangeTokenForBuild(postConfig).then((buildToken) => {


### PR DESCRIPTION
## Context
Temporal JWT is breaking `build timeout` feature since it's setting the JWT expiration time exactly the same as the `buildTimeout`. But after we got the JWT, we still need to do some pre-setup for the build, e.g.pulling image, and also teardown steps after the timeout. But the token expires too fast for those operations.

## Objective
This PR will add 30 mins buffer to user configured timeout when exchanging the JWT token, e.g. build_timeout 60 mins, JWT will be valid for 90 mins. We should probably figure out a better solution in the future.