### PR TITLE
feat(1167): [3][small] remove exchangeTokenForBuild method

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,13 +41,11 @@
     "eslint": "^4.19.1",
     "eslint-config-screwdriver": "^3.0.0",
     "jenkins-mocha": "^4.0.0",
-    "mockery": "^2.0.0",
-    "sinon": "^2.3.1"
+    "mockery": "^2.0.0"
   },
   "dependencies": {
     "joi": "^13.0.0",
     "jsonwebtoken": "^8.2.2",
-    "requestretry": "^1.13.0",
     "screwdriver-data-schema": "^18.20.0"
   }
 }


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
For issue https://github.com/screwdriver-cd/screwdriver/issues/1167 , we should exchange temporary JWT token in launcher, not in executor-*.

## Objective
<!-- What does this PR fix? What intentional changes will this PR make? -->
I removed exchangeTokenForBuild method form executor-base.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
issue: https://github.com/screwdriver-cd/screwdriver/issues/1167
related PR:
launcher: https://github.com/screwdriver-cd/launcher/pull/201
executor-k8s: https://github.com/screwdriver-cd/executor-k8s/pull/88
executor-k8s-vm: https://github.com/screwdriver-cd/executor-k8s-vm/pull/35
executor-docker: https://github.com/screwdriver-cd/executor-docker/pull/27
executor-jenkins: https://github.com/screwdriver-cd/executor-jenkins/pull/23

This PR will be merged after exchangeTokenForBuild method is removed from executor-*.