### PR TITLE
fix(757): add parseAnnotations function

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,16 @@
 const Joi = require('joi');
 const dataSchema = require('screwdriver-data-schema');
 const executorSchema = dataSchema.plugins.executor;
+const ANNOTATIONS = [
+    'screwdriver.cd/cpu',
+    'screwdriver.cd/ram',
+    'screwdriver.cd/disk',
+    'screwdriver.cd/timeout',
+    'screwdriver.cd/executor',
+    'screwdriver.cd/buildPeriodically',
+    'screwdriver.cd/repoManifest'
+];
+const annotationRe = /screwdriver.cd\/(\w+)/;
 
 /**
  * Validate the config using the schema
@@ -120,6 +130,26 @@ class Executor {
      */
     stats() {
         return {};
+    }
+
+    /**
+     * Parsed annotations object
+     * @method parseAnnotations
+     * @return {Object} object           Object contains parsed annotations
+     */
+    parseAnnotations(annotations) {
+        const parsedAnnotations = {};
+
+        Object.keys(annotations).forEach((key) => {
+            const parsedKey = key.replace(/^beta./, '');
+
+            if (ANNOTATIONS.includes(parsedKey)) {
+                // First group will be the part after slash, e.g. cpu, ram, disk
+                parsedAnnotations[parsedKey.match(annotationRe)[1]] = annotations[key];
+            }
+        });
+
+        return parsedAnnotations;
     }
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -134,6 +134,21 @@ describe('index test', () => {
             })
     ));
 
+    it('parseAnnotations returns a parsed object', () => {
+        const parsed = instance.parseAnnotations({
+            'beta.screwdriver.cd/cpu': 'HIGH',
+            'beta.screwdriver.cd/ram': 'LOW',
+            'screwdriver.cd/disk': 'HIGH',
+            'invald.screwdriver.cd': 'invalid'
+        });
+
+        assert.deepEqual(parsed, {
+            cpu: 'HIGH',
+            ram: 'LOW',
+            disk: 'HIGH'
+        });
+    });
+
     it('can be extended', () => {
         class Foo extends Executor {
             _stop(config) {


### PR DESCRIPTION
Now all executors can just call this `parseAnnotations` function to parse annotations and get valid results.

With this change, `beta.screwdriver.cd` and `screwdriver.cd` will both work.