### PR TITLE
[3] feat(1270): allow build in executor start

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ class Executor {
      * @param  {Object} config               Configuration
      * @param  {Object} [config.annotations] Optional key/value object
      * @param  {String} config.apiUri        Screwdriver's API
+     * @param  {Object} [config.build]       Build object
      * @param  {String} config.buildId       Unique ID for a build
      * @param  {String} config.container     Container for the build to run in
      * @param  {String} config.token         JWT to act on behalf of the build

--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "dependencies": {
     "joi": "^13.0.0",
     "jsonwebtoken": "^8.2.2",
-    "screwdriver-data-schema": "^18.20.0"
+    "screwdriver-data-schema": "^18.37.0"
   }
 }


### PR DESCRIPTION
Pull in new data-schema

Blocked by: https://github.com/screwdriver-cd/data-schema/pull/300
Related: https://github.com/screwdriver-cd/screwdriver/issues/1270