### PR TITLE
feat(675): Implement functions for freeze windows BREAKING CHANGE: Adds stopFrozen() and startFrozen() to be implemented inside executors

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,34 @@ class Executor {
     }
 
     /**
+      * Starts a new frozen build in an executor
+      * @method _startFrozen
+      * @param {Object} config               Configuration
+      * @return {Promise}
+      */
+    startFrozen(config) {
+        return this._startFrozen(config);
+    }
+
+    async _startFrozen() {
+        throw new Error('Not implemented');
+    }
+
+    /**
+     * Stops a previously scheduled frozen build in an executor
+     * @async  _stopFrozen
+     * @param  {Object}  config        Configuration
+     * @return {Promise}
+     */
+    stopFrozen(config) {
+        return this._stopFrozen(config);
+    }
+
+    async _stopFrozen() {
+        throw new Error('Not implemented');
+    }
+
+    /**
      * Get the status of a build
      * @method status
      * @param  {Object} config               Configuration

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -24,6 +24,8 @@ describe('index test', () => {
                     stop: Joi.object().required(),
                     startPeriodic: Joi.object().required(),
                     stopPeriodic: Joi.object().required(),
+                    startFrozen: Joi.object().required(),
+                    stopFrozen: Joi.object().required(),
                     status: Joi.object().required()
                 }
             }
@@ -106,6 +108,26 @@ describe('index test', () => {
 
     it('stopPeriodic returns an error when not overridden', () => (
         instance.stopPeriodic({})
+            .then(() => {
+                throw new Error('Oh no');
+            }, (err) => {
+                assert.isOk(err, 'error is null');
+                assert.equal(err.message, 'Not implemented');
+            })
+    ));
+
+    it('startFrozen returns an error when not overridden', () => (
+        instance.startFrozen({})
+            .then(() => {
+                throw new Error('Oh no');
+            }, (err) => {
+                assert.isOk(err, 'err is null');
+                assert.equal(err.message, 'Not implemented');
+            })
+    ));
+
+    it('stopFrozen returns an error when not overridden', () => (
+        instance.stopFrozen({})
             .then(() => {
                 throw new Error('Oh no');
             }, (err) => {


### PR DESCRIPTION
Reverts screwdriver-cd/executor-base#53