### PR TITLE
feat: Select specific node by configuring node label

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const ANNOTATIONS = [
     'screwdriver.cd/repoManifest',
     'screwdriver.cd/dockerEnabled',
     'screwdriver.cd/dockerCpu',
-    'screwdriver.cd/dockerRam'
+    'screwdriver.cd/dockerRam',
+    'screwdriver.cd/nodeLabel'
 ];
 const annotationRe = /screwdriver.cd\/(\w+)/;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -161,13 +161,15 @@ describe('index test', () => {
             'beta.screwdriver.cd/cpu': 'HIGH',
             'beta.screwdriver.cd/ram': 'LOW',
             'screwdriver.cd/disk': 'HIGH',
+            'screwdriver.cd/nodeLabel': 'foo-label',
             'invald.screwdriver.cd': 'invalid'
         });
 
         assert.deepEqual(parsed, {
             cpu: 'HIGH',
             ram: 'LOW',
-            disk: 'HIGH'
+            disk: 'HIGH',
+            nodeLabel: 'foo-label'
         });
     });
 


### PR DESCRIPTION
## Context

To select specific Jenkins node, `nodeLabel` as annotation is added in this PR.
We want to select specific Jenkins node, but this repository is base of executors.
So, we added `nodeLabel` as annotation, to use in other components such as k8s-excutor.
If there is any better annotation, please let us know.

## Objective

To select specific node,  annotation is added  in screwdriver.yaml  as below.

```
annotations:
  screwdriver.cd/nodeLabel: foo-label
```

## References

related PR: https://github.com/att55/executor-jenkins/pull/1