### PR TITLE
feat(1610): Add cleanup method

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,19 @@ The `exchangeTokenForBuild` function will call API to exchange temporary build J
 ##### Expected Return
 A Promise which resolves to actual build JWT
 
+
+#### CleanUp
+##### Expected Outcome
+The cleanUp function is expected to handle any housekeeping operations like closing connections, queues during the SIGTERM event.
+Default is no-op
+
+##### Expected Return
+A Promise that resolves or rejects.
+
+
 ## Extending
 To make use of the validation function for start and stop, you need to
-override the `_start` and `_stop` methods.
+override the `_start` , `_stop` and `_cleanUp` methods.
 
 ```js
 class MyExecutor extends Executor {

--- a/index.js
+++ b/index.js
@@ -158,6 +158,18 @@ class Executor {
     }
 
     /**
+     * Clean up any processing tasks
+     * @method cleanUp
+     */
+    async cleanUp() {
+        await this._cleanUp();
+    }
+
+    async _cleanUp() {
+        // no-op in case no implemented in extenders
+    }
+
+    /**
      * Return statistics on the executor
      * @method stats
      * @return {Object} object           Hash containing metrics for the executor

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,6 +156,13 @@ describe('index test', () => {
             })
     ));
 
+    it('cleanUp does not returns error when not overridden', () => (
+        instance.cleanUp()
+            .then(() => Promise.resolve(), (err) => {
+                assert.isOk(err, 'error is null');
+            })
+    ));
+
     it('parseAnnotations returns a parsed object', () => {
         const parsed = instance.parseAnnotations({
             'beta.screwdriver.cd/cpu': 'HIGH',


### PR DESCRIPTION
## Context

Currently when the node process terminates it happens abruptly and the in process messages are lost

## Objective

This PR adds an abstract cleanup function

## References

https://github.com/screwdriver-cd/screwdriver/issues/1610

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
