### PR TITLE
Add stop and start timer functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,37 @@ Default is no-op
 ##### Expected Return
 A Promise that resolves or rejects.
 
+#### StartTimer
+##### Required Parameters
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.annotations | Object | Optional key/value object |
+| config.buildStatus | String | The status of the  build |
+| config.buildId | String | The unique ID for a build |
+| config.startTime | String | ISO start time of the build |
+| config.jobId | String | job id of the build |
+##### Expected Outcome
+The StartTimer function is expected to add buildId as key and timeout config value to timeout queue
+Default is no-op
+
+##### Expected Return
+A Promise that resolves or rejects.
+
+#### StopTimer
+##### Required Parameters
+| Parameter        | Type  |  Description |
+| :-------------   | :---- | :-------------|
+| config        | Object | Configuration Object |
+| config.buildId | String | The unique ID for a build |
+##### Expected Outcome
+The StopTimer function is expected to remove key/value buildId from timeout queue
+Default is no-op
+
+##### Expected Return
+A Promise that resolves or rejects.
+
+
 ## Extending
 To make use of the validation function for start and stop, you need to
 override the `_start` , `_stop` and `_cleanUp` methods.

--- a/index.js
+++ b/index.js
@@ -188,8 +188,10 @@ class Executor {
 
     /**
      * Removes information from the timeout queue
+     * @method status
      * @param  {Object} config               Configuration
      * @param  {String} config.buildId       Unique ID for a build
+     * @return {Promise}
      */
     stopTimer(config) {
         return this._stopTimer(config);

--- a/index.js
+++ b/index.js
@@ -182,6 +182,18 @@ class Executor {
     }
 
     /**
+     * removes information from the timeout queue
+     * @param {*} config
+     */
+    stopTimer(config) {
+        return this._stopTimer(config);
+    }
+
+    async _stopTimer() {
+        // no-op in case no implemented in extenders
+    }
+
+    /**
      * Return statistics on the executor
      * @method stats
      * @return {Object} object           Hash containing metrics for the executor

--- a/index.js
+++ b/index.js
@@ -166,31 +166,37 @@ class Executor {
     }
 
     async _cleanUp() {
-        // no-op in case no implemented in extenders
+        // no-op in case not implemented in extenders
     }
 
     /**
      * Adds information to the timeout queue
-     * @param {Object} config
+     * @method status
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
+     * @param  {String} config.startTime     Start time fo build
+     * @param  {String} config.buildStatus     Status of build
+     * @return {Promise}
      */
     startTimer(config) {
         return this._startTimer(config);
     }
 
     async _startTimer() {
-        // no-op in case no implemented in extenders
+        // no-op in case not implemented in extenders
     }
 
     /**
-     * removes information from the timeout queue
-     * @param {*} config
+     * Removes information from the timeout queue
+     * @param  {Object} config               Configuration
+     * @param  {String} config.buildId       Unique ID for a build
      */
     stopTimer(config) {
         return this._stopTimer(config);
     }
 
     async _stopTimer() {
-        // no-op in case no implemented in extenders
+        // no-op in case not implemented in extenders
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -156,6 +156,20 @@ describe('index test', () => {
             })
     ));
 
+    it('startTimer does not returns error when not overridden', () => (
+        instance.startTimer()
+            .then(() => Promise.resolve(), (err) => {
+                assert.isOk(err, 'error is null');
+            })
+    ));
+
+    it('stopTimer does not returns error when not overridden', () => (
+        instance.stopTimer()
+            .then(() => Promise.resolve(), (err) => {
+                assert.isOk(err, 'error is null');
+            })
+    ));
+
     it('cleanUp does not returns error when not overridden', () => (
         instance.cleanUp()
             .then(() => Promise.resolve(), (err) => {


### PR DESCRIPTION
## Context

Build needs to store and clear the start time information so we add two new functions

## Objective

This will allow executor to extend functions to save and clear timeout information of build

## References

https://github.com/screwdriver-cd/screwdriver/issues/1839

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
