### PR TITLE
feat: Add annotation to executor base

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const ANNOTATIONS = [
     'screwdriver.cd/dockerEnabled',
     'screwdriver.cd/dockerCpu',
     'screwdriver.cd/dockerRam',
-    'screwdriver.cd/nodeLabel'
+    'screwdriver.cd/nodeLabel',
+    'screwdriver.cd/terminationGracePeriodSeconds'
 ];
 const annotationRe = /screwdriver.cd\/(\w+)/;
 


### PR DESCRIPTION
## Context

Currently if a build is aborted the teardown steps don't run and hence generated artifacts are not available in this case, so we need to increase the grace period before pod termination to run the artifact saving steps

## Objective

This PR adds provision to increase pod timeout by using annotations

## References

https://github.com/screwdriver-cd/screwdriver/issues/1125

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
