### PR TITLE
feat: make verify fn a no-op if not implemented

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ class Executor {
     }
 
     async _verify() {
-        throw new Error('Not implemented');
+        // no-op in case not implemented in extenders
     }
 
     /**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -79,14 +79,13 @@ describe('index test', () => {
             }
         ));
 
-    it('verify returns an error when not overridden', () =>
+    it('verify does not return an error when not overridden', () =>
         instance.verify({}).then(
-            () => {
-                throw new Error('Oh no');
+            message => {
+                assert.equal(message, undefined);
             },
-            err => {
-                assert.isOk(err, 'err is null');
-                assert.equal(err.message, 'Not implemented');
+            () => {
+                throw new Error('should not fail');
             }
         ));
 


### PR DESCRIPTION
## Context

We don't want executors not extending verify method to fail

## Objective

This PR updated verify function to a no-op so that executors do not throw an error if not extended.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
