### PR TITLE
fix(1500): [1] add unzipArtifacts method

### DIFF
--- a/index.js
+++ b/index.js
@@ -241,6 +241,20 @@ class Executor {
 
         return parsedAnnotations;
     }
+
+    /**
+     * Unzip the ZIP of artifacts
+     * @method unzipArtifacts
+     * @param  {Object} config       Configuration
+     * @return {Promise}
+     */
+    unzipArtifacts(config) {
+        return this._unzipArtifacts(config);
+    }
+
+    async _unzipArtifacts() {
+        throw new Error('Not implemented');
+    }
 }
 
 module.exports = Executor;

--- a/index.js
+++ b/index.js
@@ -245,7 +245,8 @@ class Executor {
     /**
      * Unzip the ZIP of artifacts
      * @method unzipArtifacts
-     * @param  {Object} config       Configuration
+     * @param  {Object}  config           Configuration
+     * @param  {Integer} config.buildId   Unique ID for a build
      * @return {Promise}
      */
     unzipArtifacts(config) {

--- a/index.js
+++ b/index.js
@@ -246,7 +246,7 @@ class Executor {
      * Unzip the ZIP of artifacts
      * @method unzipArtifacts
      * @param  {Object}  config           Configuration
-     * @param  {Integer} config.buildId   Unique ID for a build
+     * @param  {Number}  config.buildId   Unique ID for a build
      * @return {Promise}
      */
     unzipArtifacts(config) {

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/executor-base.git"
+    "url": "git+https://github.com/screwdriver-cd/executor-base.git"
   },
   "homepage": "https://github.com/screwdriver-cd/executor-base",
   "bugs": "https://github.com/screwdriver-cd/executor-base/issues",
@@ -31,6 +31,9 @@
     "Min Zhang <minzhang@andrew.cmu.edu>"
   ],
   "release": {
+    "branches": [
+      "master"
+    ],
     "debug": false,
     "verifyConditions": {
       "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -229,6 +229,17 @@ describe('index test', () => {
         });
     });
 
+    it('unzipArtifacts returns an error when not overridden', () =>
+        instance.unzipArtifacts({}).then(
+            () => {
+                throw new Error('Oh no');
+            },
+            err => {
+                assert.isOk(err, 'error is null');
+                assert.equal(err.message, 'Not implemented');
+            }
+        ));
+
     it('can be extended', () => {
         class Foo extends Executor {
             _stop(config) {


### PR DESCRIPTION
## Context
To implement SD_ZIP_ARTIFACTS feature by [new design](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md)

Please refer the following for the progress of this feature.
https://github.com/screwdriver-cd/screwdriver/issues/1500#issuecomment-998382248

## Objective
This PR add a new method for executor to unzip artifacts.
`SD_ZIP_ARTIFACTS` feature requires `queue-service` component according to the new design, so this new method is supposed to be supported only by `executor-queue` plugin.

## References
[design doc](https://github.com/screwdriver-cd/screwdriver/blob/0962d20d251c0b7c03d40b7e4b10bb1ed009831d/design/sd-zip-artifacts.md#sd-api-api)

[issue](https://github.com/screwdriver-cd/screwdriver/issues/1500)

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
