### PR TITLE
feat(1769): [1] Add enqueueWebhook method for queue-service cooperation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 .*.swp
 .nyc*
 .idea/
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -256,6 +256,20 @@ class Executor {
     async _unzipArtifacts() {
         throw new Error('Not implemented');
     }
+
+    /**
+     * Enqueue webhookConfig to queue service
+     * @method enqueueWebhook
+     * @param  {Object}  config           Configuration
+     * @return {Promise}
+     */
+    enqueueWebhook(config) {
+        return this._enqueueWebhook(config);
+    }
+
+    async _enqueueWebhook() {
+        throw new Error('Not implemented');
+    }
 }
 
 module.exports = Executor;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -240,6 +240,17 @@ describe('index test', () => {
             }
         ));
 
+    it('enqueueWebhook returns an error when not overridden', () =>
+        instance.enqueueWebhook({}).then(
+            () => {
+                throw new Error('Oh no');
+            },
+            err => {
+                assert.isOk(err, 'error is null');
+                assert.equal(err.message, 'Not implemented');
+            }
+        ));
+
     it('can be extended', () => {
         class Foo extends Executor {
             _stop(config) {


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
This is the implementation that follows https://github.com/screwdriver-cd/screwdriver/pull/2622.
Implemented a method to pass the webhookConfig from SCM to the queue service endpoint `/v1/queue/message?type=webhook`.
In this PR, I add a public method called by the [SD API](https://github.com/screwdriver-cd/screwdriver/pull/2627/files#diff-ac1c92f80ed73064b1f05c0d334dac456ec9692ce2e3270757507ed76db5b0f2R91), and the process is added in [other PR](https://github.com/screwdriver-cd/executor-queue/pull/99).

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Added `enqueueWebhook` method.
If the inherited class does not have `_enqueueWebhook` method, it will return an exception.

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
https://github.com/screwdriver-cd/screwdriver/issues/1769#issuecomment-934107626

Related PR
- https://github.com/screwdriver-cd/executor-queue/pull/99
- https://github.com/screwdriver-cd/screwdriver/pull/2627

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
