### PR TITLE
fix: Pull in latest data-schema with new executor start

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "joi": "^17.7.0",
-    "screwdriver-data-schema": "^22.0.1"
+    "screwdriver-data-schema": "^22.9.4"
   }
 }


### PR DESCRIPTION
## Context

Changes were made to the executor start schema.

## Objective

This PR pulls in latest data-schema.

## References

Related to https://github.com/screwdriver-cd/executor-k8s/pull/188

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
