### PR TITLE
feat(3171): Move pipeline template workflowGraph out of config into a new field

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,6 @@
   },
   "dependencies": {
     "joi": "^17.7.0",
-    "screwdriver-data-schema": "^23.0.4"
+    "screwdriver-data-schema": "^24.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "screwdriver-executor-base",
-  "version": "9.0.0",
+  "version": "10.0.0",
   "description": "Base class defining the interface for executor implementations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
BREAKING CHANGE: Move workflowGraph out of config and keep it at the same level as config

## Context

feat(3171): Move pipeline template workflowGraph out of config into a new field

## Objective

Upgrading dependencies

## References

https://github.com/screwdriver-cd/screwdriver/issues/3171

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
